### PR TITLE
Support not piping child stdio

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -7,6 +7,7 @@ var assert = require('assert');
 var c2s = require('./runnable').toString;
 var childctl = require('strong-control-channel/process');
 var debug = require('debug')('strong-runner:runner');
+var debugIo = require('debug')('strong-runner:io').enabled;
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
@@ -79,11 +80,13 @@ Runner.prototype.start = function start() {
   this.child = commit.spawn(process.execPath, args, {
     // cwd: commit.spawn sets this to working directory for commit
     env: extend(process.env, commit.env),
-    stdio: [0, 'pipe', 'pipe', 'ipc'],
+    stdio: [0, debugIo ? 1 : 'pipe', debugIo ? 2 : 'pipe', 'ipc'],
   });
 
-  this.child.stdout.pipe(this.stdout, {end: false});
-  this.child.stderr.pipe(this.stderr, {end: false});
+  if (this.child.stdout)
+    this.child.stdout.pipe(this.stdout, {end: false});
+  if (this.child.stderr)
+    this.child.stderr.pipe(this.stderr, {end: false});
 
   this.ctl = childctl.attach(this.onRequest.bind(this), this.child);
 


### PR DESCRIPTION
Its much harder to debug supervisors when the parent process pipes all
io and it has to be queried. Using `DEBUG=strong-runner:io`, all child
process stdio goes to the parents stdio, rather than being captured.

connected to strongloop-internal/scrum-nodeops#558
