### PR TITLE
win: fix issue with symlinking

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -127,7 +127,13 @@ Runner.prototype._linkPwd = function _linkPwd() {
   }
   // XXX(sam) catch errors here? this is unexpected... can't do much but log
   // and keep going
-  fs.symlinkSync(path.basename(this.commit.dir), this.PWD);
+  var targetDir = path.basename(this.commit.dir);
+  if (process.platform === 'win32') {
+    // Work around a bug in node (but not io.js) where the path is made
+    // absolute incorrectly when creating a junction.
+    targetDir = path.resolve(this.PWD, '..', targetDir);
+  }
+  fs.symlinkSync(targetDir, this.PWD, 'junction');
 };
 
 Runner.prototype.onExit = function onExit(code, signal) {


### PR DESCRIPTION
On Windows, creating a symlink requires elevation.
Create a junction instead, and work around a bug in node v0.10/v0.12
related to creating junctions.
