### PR TITLE
Support websocket control channel

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -88,7 +88,8 @@ Runner.prototype.start = function start() {
   if (this.child.stderr)
     this.child.stderr.pipe(this.stderr, {end: false});
 
-  this.ctl = childctl.attach(this.onRequest.bind(this), this.child);
+  this.ctl = this.options.ctl ||
+             childctl.attach(this.onRequest.bind(this), this.child);
 
   this.child.runner = this;
   this.child.on('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mkdirp": "^0.5.0",
     "npm-path": "^1.0.1",
     "osenv": "^0.1.0",
-    "strong-control-channel": "^1",
+    "strong-control-channel": "^2",
     "strong-fork-cicada": "^1.1.2",
     "strong-supervisor": "^3.0.0"
   }

--- a/test/test-app-stdio.js
+++ b/test/test-app-stdio.js
@@ -57,7 +57,8 @@ tap.test('stdio for workers', function(t) {
     });
   }
 
-  this.on('end', function() {
+  t.test('done', function(tt) {
     r.stop('soft');
+    tt.end();
   });
 });

--- a/test/test-runner-replace.js
+++ b/test/test-runner-replace.js
@@ -62,7 +62,8 @@ tap.test('start and replace', function(t) {
     });
   });
 
-  this.on('end', function() {
+  t.test('stop', function(tt) {
     r.stop();
+    tt.end();
   });
 });

--- a/test/test-runner-replace.js
+++ b/test/test-runner-replace.js
@@ -33,7 +33,7 @@ tap.test('start and replace', function(t) {
       debug('original on request: %j', req);
 
       if (req.cmd == 'listening') {
-        tt.equal(req.id, 1, 'worker 1 listening');
+        tt.equal(req.wid, 1, 'worker 1 listening');
       }
       if (req.cmd == 'status:wd') {
         tt.equal(req.cwd, app.dir);
@@ -53,7 +53,7 @@ tap.test('start and replace', function(t) {
       debug('replaced on request: %j', req);
 
       if (req.cmd == 'listening') {
-        tt.equal(req.id, 2, 'worker 2 listening');
+        tt.equal(req.wid, 2, 'worker 2 listening');
       }
       if (req.cmd == 'status:wd') {
         tt.equal(req.cwd, app1.dir);

--- a/test/test-runner-start-0.js
+++ b/test/test-runner-start-0.js
@@ -23,11 +23,8 @@ tap.test('start 0 workers', function(t) {
 
     if (req.cmd == 'status') {
       t.equal(req.workers.length, 0);
+      r.stop();
     }
     return callback();
-  });
-
-  this.on('end', function() {
-    r.stop();
   });
 });

--- a/test/test-runner-stdio.js
+++ b/test/test-runner-stdio.js
@@ -61,7 +61,8 @@ tap.test('stdio for workers', function(t) {
     });
   }
 
-  this.on('end', function() {
+  t.test('stop', function(tt) {
     r.stop();
+    tt.end();
   });
 });

--- a/test/test-stdio.js
+++ b/test/test-stdio.js
@@ -19,7 +19,7 @@ tap.test('stdio accumulator', function(t) {
 
   setImmediate(function() {
     stdio.pipe(dst);
-    stdio.pipe(process.stdout);
+    stdio.pipe(process.stderr);
     stdio.from(srcB);
     setImmediate(function() {
       stdio.end();


### PR DESCRIPTION
Turns out there were actually some changes required to properly support a WS-only control scenario.