### PR TITLE
Cleanup dependencies and tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-test
 node_modules
 .*

--- a/lib/app.js
+++ b/lib/app.js
@@ -72,7 +72,7 @@ App.prototype.start = function(callback) {
   current.stderr.pipe(this.stderr, {end: false});
 
   return callback();
-}
+};
 
 // Stop the current commit, if it exists.
 //

--- a/lib/app.js
+++ b/lib/app.js
@@ -81,7 +81,7 @@ App.prototype.stop = function(style, callback) {
   var self = this;
   var current = self.current;
 
-  console.log('Stop (%s) current %s', style, current || '(none)');
+  self.console.log('Stop (%s) current %s', style, current || '(none)');
 
   if (!callback)
     callback = function() {};
@@ -111,7 +111,7 @@ App.prototype.stop = function(style, callback) {
 App.prototype.request = function(req, callback) {
   var current = this.current && this.current.child && this.current;
 
-  console.log('Request (%s) of current %s', req.cmd, current || '(none)');
+  this.console.log('Request (%s) of current %s', req.cmd, current || '(none)');
 
   if (!current)
     return callback(new Error('no current application'));

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "bl": "^0.9.4",
     "byline": "^4.2.1",
-    "eslint": "^0.22.1",
+    "eslint": "^0.24.0",
     "jscs": "^1.13.1",
     "mktmpdir": "^0.1.1",
     "request": "^2.45.0",
@@ -31,7 +31,7 @@
     "async": "^0.9.0",
     "concat-stream": "^1.4.7",
     "debug": "^2.0.0",
-    "lodash": "^2.4.1",
+    "lodash": "^3.0.0",
     "mkdirp": "^0.5.0",
     "npm-path": "^1.0.1",
     "osenv": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . && jscs .",
+    "lint": "eslint ./ && jscs ./",
     "test": "tap ./test/test-*"
   },
   "bin": {},

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint ./ && jscs ./",
+    "pretest": "eslint ./ && jscs ./",
     "test": "tap ./test/test-*"
   },
   "bin": {},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "tap": "^1.2.0"
   },
   "dependencies": {
-    "async": "^0.9.0",
     "concat-stream": "^1.4.7",
     "debug": "^2.0.0",
     "lodash": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,18 +23,11 @@
     "byline": "^4.2.1",
     "eslint": "^0.24.0",
     "jscs": "^1.13.1",
-    "mktmpdir": "^0.1.1",
-    "request": "^2.45.0",
-    "semver": "^4.1.0",
     "tap": "^1.2.0"
   },
   "dependencies": {
-    "concat-stream": "^1.4.7",
     "debug": "^2.0.0",
     "lodash": "^3.0.0",
-    "mkdirp": "^0.5.0",
-    "npm-path": "^1.0.1",
-    "osenv": "^0.1.0",
     "strong-control-channel": "^2",
     "strong-fork-cicada": "^1.1.2",
     "strong-supervisor": "^3.0.0"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.tapFriendlyConsole = {
+  log: console.error,
+  error: console.error,
+};

--- a/test/run-sequence.js
+++ b/test/run-sequence.js
@@ -1,15 +1,11 @@
 'use strict';
 
 var assert = require('assert');
-var c2s = require('../').Runnable.toString;
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');
 var fmt = require('util').format;
-var fs = require('fs');
 var helpers = require('./helpers');
-var path = require('path');
 var tap = require('tap');
-var util = require('util');
 var Runner = require('../').Runner;
 
 exports.test = test;
@@ -20,7 +16,9 @@ exports.kill = kill;
 
 function test(/* steps... */) {
   var steps = Array.prototype.slice.call(arguments);
-  var description = steps.map(function(step) { return step.name; }).join(', ');
+  var description = steps.map(function(step) {
+    return step.name;
+  }).join(', ');
 
   tap.test('test sequence: ' + description, function(t) {
     steps.forEach(function(step) {
@@ -88,7 +86,6 @@ function replace(t) {
     var r = t.runner;
     var c = commit.app1();
 
-    var dir0 = r.commit.dir;
     var master0 = r.child ? r.child.pid : undefined;
     var dir1 = c.dir;
 

--- a/test/run-sequence.js
+++ b/test/run-sequence.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assert = require('assert');
-var async = require('async');
 var c2s = require('../').Runnable.toString;
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');

--- a/test/run-sequence.js
+++ b/test/run-sequence.js
@@ -7,6 +7,7 @@ var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');
 var fmt = require('util').format;
 var fs = require('fs');
+var helpers = require('./helpers');
 var path = require('path');
 var tap = require('tap');
 var util = require('util');
@@ -40,8 +41,10 @@ var startCmd = [
 function start(t) {
   t.test('start', function(tt) {
     delimit(tt, 'start');
-
-    var r = t.runner = Runner(commit.app(), {start: startCmd});
+    var r = t.runner = Runner(commit.app(), {
+      start: startCmd,
+      console: helpers.tapFriendlyConsole,
+    });
 
     r.start();
     r.on('request', wait);

--- a/test/tap.js
+++ b/test/tap.js
@@ -18,5 +18,5 @@ tap.test = function test(name) {
 
   // XXX(sam) explanation is empty, not sure how to fill it in, or if useful,
   // see above
-  return _test.call(tap, name, {skip: true}, function() {});
+  // return _test.call(tap, name, {skip: true}, function() {});
 };

--- a/test/test-app-stdio.js
+++ b/test/test-app-stdio.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var App = require('../').App;
-var assert = require('assert');
 var byline = require('byline');
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');

--- a/test/test-app-stdio.js
+++ b/test/test-app-stdio.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var byline = require('byline');
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');
+var helpers = require('./helpers');
 var tap = require('./tap');
 
 tap.test('stdio for workers', function(t) {
@@ -12,7 +13,8 @@ tap.test('stdio for workers', function(t) {
 
   var r = App({
     start: 'sl-run --cluster=0 --no-profile'
-      + '  --no-timestamp-workers --no-timestamp-supervisor'
+      + '  --no-timestamp-workers --no-timestamp-supervisor',
+    console: helpers.tapFriendlyConsole,
   });
 
   var stdout = byline(r.stdout);

--- a/test/test-app-stdio.js
+++ b/test/test-app-stdio.js
@@ -18,6 +18,11 @@ tap.test('stdio for workers', function(t) {
 
   var stdout = byline(r.stdout);
 
+  // HACK: this prevents the first line of TAP output being a plan, which is
+  // interpretted by tap4j/Jenkins as a plan for the the parent test, not the
+  // first subtest
+  t.ok(app, 'commit.app');
+
   t.test('run app', function(tt) {
     debug('wait for run');
     r.run(app);

--- a/test/test-runnable.js
+++ b/test/test-runnable.js
@@ -10,7 +10,7 @@ tap.test('runnable creation', function(t) {
 
   t.equal(r.dir, app);
   t.equal(r.env.KEY, env.KEY);
-  delete env.KEY
+  delete env.KEY;
   t.equal(r.env.KEY, 'VALUE', 'commit uses env value, not reference');
   t.assert(r.spawn);
   t.equal(r.id, undefined, 'no id');

--- a/test/test-runner-replace.js
+++ b/test/test-runner-replace.js
@@ -4,6 +4,7 @@ var Runner = require('../').Runner;
 var assert = require('assert');
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');
+var helpers = require('./helpers');
 var tap = require('./tap');
 
 // XXX could do version variations on:
@@ -18,7 +19,10 @@ tap.test('start and replace', function(t) {
 
   assert.notEqual(app.dir, app1.dir);
 
-  var r = Runner(app, {start: 'sl-run --cluster=1 --no-profile'});
+  var r = Runner(app, {
+    start: 'sl-run --cluster=1 --no-profile',
+    console: helpers.tapFriendlyConsole,
+  });
 
   r.start();
 

--- a/test/test-runner-replace.js
+++ b/test/test-runner-replace.js
@@ -36,10 +36,10 @@ tap.test('start and replace', function(t) {
 
       debug('original on request: %j', req);
 
-      if (req.cmd == 'listening') {
+      if (req.cmd === 'listening') {
         tt.equal(req.wid, 1, 'worker 1 listening');
       }
-      if (req.cmd == 'status:wd') {
+      if (req.cmd === 'status:wd') {
         tt.equal(req.cwd, app.dir);
       }
       return callback();
@@ -56,10 +56,10 @@ tap.test('start and replace', function(t) {
     r.on('request', function(req, callback) {
       debug('replaced on request: %j', req);
 
-      if (req.cmd == 'listening') {
+      if (req.cmd === 'listening') {
         tt.equal(req.wid, 2, 'worker 2 listening');
       }
-      if (req.cmd == 'status:wd') {
+      if (req.cmd === 'status:wd') {
         tt.equal(req.cwd, app1.dir);
       }
       return callback();

--- a/test/test-runner-start-0.js
+++ b/test/test-runner-start-0.js
@@ -25,7 +25,7 @@ tap.test('start 0 workers', function(t) {
   r.on('request', function(req, callback) {
     debug('on request: %j', req);
 
-    if (req.cmd == 'status') {
+    if (req.cmd === 'status') {
       t.equal(req.workers.length, 0);
       r.stop();
     }

--- a/test/test-runner-start-0.js
+++ b/test/test-runner-start-0.js
@@ -4,6 +4,7 @@ var Runner = require('../').Runner;
 var assert = require('assert');
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');
+var helpers = require('./helpers');
 var tap = require('./tap');
 
 tap.test('start 0 workers', function(t) {
@@ -12,7 +13,10 @@ tap.test('start 0 workers', function(t) {
 
   assert.notEqual(app.dir, app1.dir);
 
-  var r = Runner(app, {start: 'sl-run --cluster=0 --no-profile'});
+  var r = Runner(app, {
+    start: 'sl-run --cluster=0 --no-profile',
+    console: helpers.tapFriendlyConsole,
+  });
 
   r.start();
 

--- a/test/test-runner-stdio.js
+++ b/test/test-runner-stdio.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var byline = require('byline');
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');
+var helpers = require('./helpers');
 var tap = require('./tap');
 
 tap.test('stdio for workers', function(t) {
@@ -15,7 +16,8 @@ tap.test('stdio for workers', function(t) {
 
   var r = Runner(app, {
     start: 'sl-run --cluster=2 --no-profile'
-      + '  --no-timestamp-workers --no-timestamp-supervisor'
+      + '  --no-timestamp-workers --no-timestamp-supervisor',
+    console: helpers.tapFriendlyConsole,
   });
 
   r.start();

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,13 +1,7 @@
 'use strict';
 
-var assert = require('assert');
-var c2s = require('../').Runnable.toString;
 var commit = require('./commit');
-var debug = require('debug')('strong-runner:test');
-var fs = require('fs');
-var path = require('path');
 var tap = require('tap');
-var util = require('util');
 var Runner = require('../').Runner;
 
 tap.test('create runner with no options', function(t) {

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assert = require('assert');
-var async = require('async');
 var c2s = require('../').Runnable.toString;
 var commit = require('./commit');
 var debug = require('debug')('strong-runner:test');

--- a/test/test-stdio.js
+++ b/test/test-stdio.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Stdio = require('../lib/stdio');
-var assert = require('assert');
 var bl = require('bl');
 var tap = require('tap');
 


### PR DESCRIPTION
A bunch of cleanup.. the only thing that has any impact at all on the behaviour is fixing the `App` class to use the logger it is given instead of always logging to stdout. The functionality was already there, just inconsistently used.

@sam-github @piscisaureus this also fixes the problem CI has with the TAP output, which is the first commit.