### PR TITLE
app: don't log requests that are not made

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -111,7 +111,8 @@ App.prototype.stop = function(style, callback) {
 App.prototype.request = function(req, callback) {
   var current = this.current && this.current.child && this.current;
 
-  this.console.log('Request (%s) of current %s', req.cmd, current || '(none)');
+  if (current)
+    this.console.log('Request (%s) of current %s', req.cmd, current);
 
   if (!current)
     return callback(new Error('no current application'));


### PR DESCRIPTION
Particularly because the first 3 messages on every sl-pm startup are
requests to an undefined current, which is unnecessarily worrisome and
noisy.

connected to strongloop-internal/scrum-nodeops#747