### PR TITLE
runner: always use absolute symlink

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -129,15 +129,9 @@ Runner.prototype._linkPwd = function _linkPwd() {
   } catch (er) {
     // File didn't exist.
   }
-  // XXX(sam) catch errors here? this is unexpected... can't do much but log
-  // and keep going
-  var targetDir = path.basename(this.commit.dir);
-  if (process.platform === 'win32') {
-    // Work around a bug in node (but not io.js) where the path is made
-    // absolute incorrectly when creating a junction.
-    targetDir = path.resolve(this.PWD, '..', targetDir);
-  }
-  fs.symlinkSync(targetDir, this.PWD, 'junction');
+  // Always symlink to an absolute path, relative paths don't work on win32.
+  debug('link %s to %s', this.PWD, this.commit.dir);
+  fs.symlinkSync(this.commit.dir, this.PWD, 'junction');
 };
 
 Runner.prototype.onExit = function onExit(code, signal) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strong-runner",
   "description": "run app with strong-supervisor",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/strongloop/strong-runner.git"


### PR DESCRIPTION
Relative symlinks don't work on Win32. This is a major bump, because
strong-pm reads the symlink in order to find the current commit ID.

connected to strongloop-internal/scrum-nodeops#848