### PR TITLE
test: port to tap@1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "lint": "eslint ./ && jscs ./",
     "pretest": "eslint ./ && jscs ./",
-    "test": "tap ./test/test-*"
+    "test": "tap --bail ./test/test-*"
   },
   "bin": {},
   "devDependencies": {
@@ -23,7 +23,7 @@
     "byline": "^4.2.1",
     "eslint": "^0.24.0",
     "jscs": "^1.13.1",
-    "tap": "^1.2.0"
+    "tap": "^1.3.1"
   },
   "dependencies": {
     "debug": "^2.0.0",

--- a/test/run-sequence.js
+++ b/test/run-sequence.js
@@ -24,6 +24,8 @@ function test(/* steps... */) {
     steps.forEach(function(step) {
       step(t);
     });
+
+    t.end();
   });
 }
 
@@ -98,32 +100,44 @@ function replace(t) {
     r.on('request', wait);
 
     function wait(req) {
+      if (req.cmd === 'status') {
+        // Replace is complete when the old worker is gone.
+        var master1 = r.child.pid;
+        var workers1 = t.status.workers;
+
+        if (workers0[0] && workers0[0].pid === workers1[0].pid) {
+          debug('worker[0] not replaced');
+          return;
+        }
+
+        if (master0) {
+          tt.equal(master0, master1, 'supervisor has same pid');
+          assert.equal(workers0.length, workers1.length, 'all restarted');
+        } else {
+          tt.assert(master1 > 0, 'supervisor restarted');
+          tt.equal(workers0.length, 0, 'stopped master has no workers');
+        }
+
+        workers0.forEach(function(w0, i) {
+          var w1 = workers1[i];
+          assert.notEqual(w0.id, w1.id, fmt('idx %d w0 %j w1 %j', i, w0, w1));
+          assert.notEqual(w0.pid, w1.pid, fmt('idx %d w0 %j w1 %j', i, w0, w1));
+        });
+
+        r.removeListener('request', wait);
+        tt.end();
+      }
+
       if (req.cmd !== 'status:wd')
         return;
-      r.removeListener('request', wait);
 
       debug('replace: new wd: %j', req);
       debug('replace: new status: %j', t.status);
 
-      var master1 = r.child.pid;
       var cwd1 = req.cwd;
       var pwd1 = req.pwd;
-      var workers1 = t.status.workers;
-      if (master0) {
-        t.equal(master0, master1, 'supervisor has same pid');
-        assert.equal(workers0.length, workers1.length, 'all workers restarted');
-      } else {
-        t.assert(master1 > 0, 'supervisor restarted');
-        t.equal(workers0.length, 0, 'stopped master has no workers');
-      }
-      workers0.forEach(function(w0, i) {
-        var w1 = workers1[i];
-        assert.notEqual(w0.id, w1.id, fmt('idx %d w0 %j w1 %j', i, w0, w1));
-        assert.notEqual(w0.pid, w1.pid, fmt('idx %d w0 %j w1 %j', i, w0, w1));
-      });
-      t.equal(cwd1, dir1, 'worker is in app1 directory');
-      t.equal(pwd1, r.PWD, 'worker has virtual PWD');
-      tt.end();
+      tt.equal(cwd1, dir1, 'worker is in app1 directory');
+      tt.equal(pwd1, r.PWD, 'worker has virtual PWD');
     }
   });
 }
@@ -162,6 +176,6 @@ function kill(t) {
 function delimit(tt, name) {
   debug('sub-test: %s (begin)', name);
   tt.on('end', function() {
-    debug('sub-test: %s (complete)', name);
+    debug('sub-test: %s (on end)', name);
   });
 }

--- a/test/test-app-stdio.js
+++ b/test/test-app-stdio.js
@@ -67,4 +67,6 @@ tap.test('stdio for workers', function(t) {
     r.stop('soft');
     tt.end();
   });
+
+  t.end();
 });

--- a/test/test-runner-replace.js
+++ b/test/test-runner-replace.js
@@ -70,4 +70,6 @@ tap.test('start and replace', function(t) {
     r.stop();
     tt.end();
   });
+
+  t.end();
 });

--- a/test/test-runner-stdio.js
+++ b/test/test-runner-stdio.js
@@ -67,4 +67,6 @@ tap.test('stdio for workers', function(t) {
     r.stop();
     tt.end();
   });
+
+  t.end();
 });


### PR DESCRIPTION
It now requires a t.end() at the end of sub-tests.