### PR TITLE
runner: restart using control channel, not SIGHUP

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -233,8 +233,6 @@ Runner.prototype.toString = function toString() {
 
 // Replace currently running commit with next commit.
 Runner.prototype.replace = function replace(next) {
-  var signame = 'SIGHUP';
-
   if (envChanged(this.commit.env, next.env)) {
     this.console.log('ENV has changed, restarting');
     this.nextCommit = next;
@@ -251,18 +249,12 @@ Runner.prototype.replace = function replace(next) {
     // Current app is not running, so just start again with the current commit.
     return this.start();
   }
-  try {
-    this.child.kill(signame);
-  } catch (err) {
-    if (err.code === 'ESRCH') {
-      // Child died as we were trying to replace it... let normal restart on
-      // failure handle this.
-      return;
-    }
-    this.console.error('Restart process %d with %s failed: %s',
-      this.child.pid, signame, err);
-    // XXX if we can't signal our children, not sure what we can do
-  }
+  this.request({cmd: 'restart'}, function(rsp) {
+    // On failure, the ctl channel has been lost, so the child is already
+    // dead, or in process of dieing, and we don't have to handle this.
+    if (rsp.error)
+      debug('restart command to %d failed: %s', this.child.pid, rsp.error);
+  });
 
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "lodash": "^3.0.0",
     "strong-control-channel": "^2",
     "strong-fork-cicada": "^1.1.2",
-    "strong-supervisor": "^3.0.0"
+    "strong-supervisor": "^3.1.0"
   }
 }


### PR DESCRIPTION
Signalling with SIGHUP is not supported on Windows, and is unnecessary
since there is already a restart command supported over the control
channel.

replace https://github.com/strongloop/strong-runner/pull/12
connected to strongloop-internal/scrum-nodeops#455
depends on https://github.com/strongloop/strong-supervisor/pull/157